### PR TITLE
Add option to disable warning of extraneous ruby- prefix in version

### DIFF
--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -21,9 +21,11 @@ version_exists() {
 if version_exists "$RBENV_VERSION"; then
   echo "$RBENV_VERSION"
 elif version_exists "${RBENV_VERSION#ruby-}"; then
-  { echo "warning: ignoring extraneous \`ruby-' prefix in version \`${RBENV_VERSION}'"
-    echo "         (set by $(rbenv-version-origin))"
-  } >&2
+  if [ -z "$RBENV_VERSION_PREFIX_NOWARN" ]; then
+    { echo "warning: ignoring extraneous \`ruby-' prefix in version \`${RBENV_VERSION}'"
+      echo "         (set by $(rbenv-version-origin))"
+    } >&2
+  fi
   echo "${RBENV_VERSION#ruby-}"
 else
   echo "rbenv: version \`$RBENV_VERSION' is not installed" >&2

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -63,3 +63,13 @@ warning: ignoring extraneous \`ruby-' prefix in version \`ruby-1.8.7'
 1.8.7
 OUT
 }
+
+@test "version with prefix in name when warning disabled" {
+  create_version "1.8.7"
+  cat > ".ruby-version" <<<"ruby-1.8.7"
+  RBENV_VERSION_PREFIX_NOWARN=1 run rbenv-version-name
+  assert_success
+  assert_output <<OUT
+1.8.7
+OUT
+}


### PR DESCRIPTION
Set `RBENV_VERSION_PREFIX_NOWARN`, for example in your `~/.zshrc` or `~/.bashrc`, to disable warnings of the extraneous `ruby-` prefix in `.ruby-version` files.

rbenv's behaviour is inconsitent with other Ruby version managers. If you work on projects with others who use a Ruby version manager that prefers the `ruby-` prefix, you will see this warning every time you run a shell command in a Ruby project that has the prefix.

Further discussion of the warning exists in https://github.com/sstephenson/rbenv/issues/543, such as whether the warning should exist or not in the first place. This just adds the option to disable it, leaving the default functionality as is.