### PR TITLE
Use `command` to run rbenv rehash

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -88,7 +88,7 @@ if [ -r "$completion" ]; then
 fi
 
 if [ -z "$no_rehash" ]; then
-  echo 'rbenv rehash 2>/dev/null'
+  echo 'command rbenv rehash 2>/dev/null'
 fi
 
 commands=(`rbenv-commands --sh`)

--- a/test/init.bats
+++ b/test/init.bats
@@ -14,7 +14,7 @@ load test_helper
 @test "auto rehash" {
   run rbenv-init -
   assert_success
-  assert_line "rbenv rehash 2>/dev/null"
+  assert_line "command rbenv rehash 2>/dev/null"
 }
 
 @test "setup shell completions" {


### PR DESCRIPTION
In the event that `eval "$(rbenv init -)"` is called from a function named
rbenv (which I do to get rbenv to load lazily in my shell), evaluating the
phrase `rbenv rehash` will cause the outer function to run again (causing an
infinite loop).

This change makes it clear you want the command named rbenv and not a function
which may exist in the environment.

I ran this locally and ran the tests to ensure this change doesn't break anything. 

An example of where this is useful would be if you wanted to lazy load the rbenv process on its first invocation (like I do). You can do so with a function like this in your .zshrc:

```zsh
    rbenv() {
        eval "$( command rbenv init - )"
        rbenv "$@"
    }
```

Otherwise running `rbenv init -` takes anywhere from 90ms to 120ms in the shell startup process. Without this pull request, the function above calls itself in an infinite loop.
