### PR TITLE
Include gems dir in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /libexec/*.dylib
 /src/Makefile
 /src/*.o
+/gems


### PR DESCRIPTION
Since communal-gems is maintainer-approved, thought it would be useful to include the directory it uses in the ignore list.

(This also helps me, since I install rbenv as submodule and without this entry, the submodule is perpetually marked dirty.)