### PR TITLE
Remove warning about extraneous "ruby-" prefix in `.ruby-version`

### DIFF
--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -21,9 +21,6 @@ version_exists() {
 if version_exists "$RBENV_VERSION"; then
   echo "$RBENV_VERSION"
 elif version_exists "${RBENV_VERSION#ruby-}"; then
-  { echo "warning: ignoring extraneous \`ruby-' prefix in version \`${RBENV_VERSION}'"
-    echo "         (set by $(rbenv-version-origin))"
-  } >&2
   echo "${RBENV_VERSION#ruby-}"
 else
   echo "rbenv: version \`$RBENV_VERSION' is not installed" >&2

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -57,9 +57,5 @@ setup() {
   cat > ".ruby-version" <<<"ruby-1.8.7"
   run rbenv-version-name
   assert_success
-  assert_output <<OUT
-warning: ignoring extraneous \`ruby-' prefix in version \`ruby-1.8.7'
-         (set by ${PWD}/.ruby-version)
-1.8.7
-OUT
+  assert_output "1.8.7"
 }


### PR DESCRIPTION
People are often not able to remove the prefix in their projects because they want to support other coworkers and tools that sadly still require the prefix, like RubyMine.

So to restore sanity for a big portion of our users, the warning is now gone.

Fixes #543, closes #650

/cc @konklone @lucaspiller