### PR TITLE
Update README to make rbenv version consistent with previous `versions` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Displays the currently active Ruby version, along with information on
 how it was set.
 
     $ rbenv version
-    1.8.7-p352 (set by /Volumes/37signals/basecamp/.ruby-version)
+    1.9.3-p327 (set by /Users/sam/.rbenv/version)
 
 ### rbenv rehash
 


### PR DESCRIPTION
The `rbenv versions` info highlights 1.9.3-p327 as the current version, and making `rbenv version` sample output match that helps make it clearer.