### PR TITLE
Fix pattern replacement to allow flags with commas.

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -39,8 +39,8 @@ sed "
   s,@SHOBJ_CC@,${SHOBJ_CC},
   s,@SHOBJ_CFLAGS@,${SHOBJ_CFLAGS},
   s,@SHOBJ_LD@,${SHOBJ_LD},
-  s,@SHOBJ_LDFLAGS@,${SHOBJ_LDFLAGS//,/\,},
-  s,@SHOBJ_XLDFLAGS@,${SHOBJ_XLDFLAGS//,/\,},
+  s,@SHOBJ_LDFLAGS@,${SHOBJ_LDFLAGS//,/\\,},
+  s,@SHOBJ_XLDFLAGS@,${SHOBJ_XLDFLAGS//,/\\,},
   s,@SHOBJ_LIBS@,${SHOBJ_LIBS},
   s,@SHOBJ_STATUS@,${SHOBJ_STATUS},
 " "$src_dir"/Makefile.in > "$src_dir"/Makefile


### PR DESCRIPTION
I couldn't get the realpath builtin to compile on Ubuntu 14.04 because the LDFLAGS it requires contains commas. I was getting the following:

    ~/.rbenv$ ./src/configure
    sed: -e expression #1, char 184: unknown option to `s'

I tracked it down to a missing level of quoting in the replacement string included in the sed commands.

/cc @mislav