### PR TITLE
rbenv-init: add "toward the end" to install instructions

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -50,7 +50,7 @@ if [ -z "$print" ]; then
   esac
 
   { echo "# Load rbenv automatically by adding"
-    echo "# the following to ${profile}:"
+    echo "# the following toward the end of ${profile}:"
     echo
     case "$shell" in
     fish )


### PR DESCRIPTION
This was suggested in https://github.com/yyuu/pyenv/pull/313.