### PR TITLE
rbenv-init: do not use basename for $shell

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -25,7 +25,8 @@ if [ -z "$shell" ]; then
   shell="$(ps c -p "$PPID" -o 'ucomm=' 2>/dev/null || true)"
   shell="${shell##-}"
   shell="${shell%% *}"
-  shell="$(basename "${shell:-$SHELL}")"
+  shell="${shell:-$SHELL}"
+  shell="${shell##*/}"
 fi
 
 root="${0%/*}/.."


### PR DESCRIPTION
This can be done using bash directly.