### PR TITLE
rbenv-rehash: look for program==ruby*

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -46,7 +46,7 @@ set -e
 [ -n "\$RBENV_DEBUG" ] && set -x
 
 program="\${0##*/}"
-if [ "\$program" = "ruby" ]; then
+if [[ "\$program" =~ ^ruby([0-9][.0-9]+)?$ ]]; then
   for arg; do
     case "\$arg" in
     -e* | -- ) break ;;


### PR DESCRIPTION
When "program" is not ruby, but e.g. ruby2.1, it should be handled
specially, too.

I came across this for pyenv.
Some discussion: https://github.com/yyuu/pyenv/pull/368#issuecomment-102810231