### PR TITLE
Don't change global git configuration. fixes #741

### DIFF
--- a/test/--version.bats
+++ b/test/--version.bats
@@ -2,10 +2,9 @@
 
 load test_helper
 
-setup() {
-  mkdir -p "$HOME"
-  git config --global user.name  "Tester"
-  git config --global user.email "tester@test.local"
+git_config_user() {
+  git config user.name  "Tester"
+  git config user.email "tester@test.local"
 }
 
 git_commit() {
@@ -23,6 +22,7 @@ git_commit() {
   mkdir -p "$RBENV_ROOT"
   cd "$RBENV_ROOT"
   git init
+  git_config_user
   git_commit
   git tag v0.4.1
   git_commit
@@ -38,6 +38,7 @@ git_commit() {
   mkdir -p "$RBENV_ROOT"
   cd "$RBENV_ROOT"
   git init
+  git_config_user
   git_commit
 
   cd "$RBENV_TEST_DIR"

--- a/test/--version.bats
+++ b/test/--version.bats
@@ -2,7 +2,10 @@
 
 load test_helper
 
-git_config_user() {
+setup_rbenv_git_clone(){
+  mkdir -p "$RBENV_ROOT"
+  cd "$RBENV_ROOT"
+  git init
   git config user.name  "Tester"
   git config user.email "tester@test.local"
 }
@@ -19,10 +22,8 @@ git_commit() {
 }
 
 @test "reads version from git repo" {
-  mkdir -p "$RBENV_ROOT"
-  cd "$RBENV_ROOT"
-  git init
-  git_config_user
+  setup_rbenv_git_clone
+
   git_commit
   git tag v0.4.1
   git_commit
@@ -35,10 +36,8 @@ git_commit() {
 }
 
 @test "prints default version if no tags in git repo" {
-  mkdir -p "$RBENV_ROOT"
-  cd "$RBENV_ROOT"
-  git init
-  git_config_user
+  setup_rbenv_git_clone
+
   git_commit
 
   cd "$RBENV_TEST_DIR"


### PR DESCRIPTION
`test/--version.bats` needs to create a local fake clone of rbenv in order to test the `--version` flag. In order to set up the test scenario correctly, the fake rbenv clone needs to have some commits and tags, which means a user (name/email) must be set.

Previously, this test was relying on the fact that the test suite operates under a different `$HOME`. This meant that the global git configuration was being set only in `$RBENV_TEST_DIR/home/.gitconfig`. However, git has supported the XDG BaseDir spec for some time now. Which means that git will prefer `$XDG_CONFIG_HOME/git/config` over `$HOME/.gitconfig`. Which meant that running this test suite on a system with XDG_CONFIG_HOME set would alter the user's actual user name and email.

One solution is to change the `$XDG_CONFIG_HOME` environment variable during the test run. However, in order to fully insulate the test suite from XDG setups, we would *also* have to overwrite the `$XDG_CONFIG_DIRS` var. This is an aweful lot of environment tweaking when all we really want to do is get some commits into our fake rbenv git repo.

So, rather than continue to monkey with the global git config, this PR simply sets the user's name/email *local to* the git repo. (That is, under `$RBENV_TEST_DIR/root/.git/config`, which is done by default for any git-config command without the `--global` flag.) This way the temporary git configuration is kept local to the temporary git repo itself.

In fact, the user name/email may not even be necessary at all. Current versions of git emit a warning message when a git-commit is made while the user isn't set. However, the commit itself still succeeds and returns a successful status code. This PR doesn't rely on this behavior, however, because it's possible that older versions of git treat an un-set user as an actual error. But this remains a potential cleanup–depending on which versions of git we support (and if any version of git actually treats an un-set user as an actual error.)

In addition to making the git config setting local (which meant moving the commands from setup to after the git-init call), I factored out a function that does all of the git setup (creating the repo directory, changing dirs into it, initializing the git repo, and configuring the user).

If it weren't for the `default` test, all of these steps could have remained in `setup`.

#741 