### PR TITLE
WIP `bundle install` hook

### DIFF
--- a/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
+++ b/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
@@ -10,9 +10,33 @@ hook = lambda do |installer|
   end
 end
 
-begin
-  Gem.post_install(&hook)
-  Gem.post_uninstall(&hook)
-rescue
-  warn "rbenv: error installing gem-rehash hooks (#{$!})"
+if defined?(Bundler::Installer) && Bundler::Installer.respond_to?(:install)
+  warn "bundler hook"
+  Bundler::Installer.class_eval do
+    class << self
+      alias install_without_rbenv_rehash install
+      def install(root, definition, options = {})
+        result = install_without_rbenv_rehash(root, definition, options)
+        begin
+          warn "%p %p" % [ Gem.default_path, Bundler.bundle_path ]
+          warn "result: %p" % result
+          if result && Gem.default_path.include?(Bundler.bundle_path)
+            warn "REHASHING from bundler"
+            system "rbenv", "rehash"
+          end
+        rescue
+          warn "rbenv: error in bundle post-install hook (#{$!})"
+        end
+        result
+      end
+    end
+  end
+else
+  warn "normal hook"
+  begin
+    Gem.post_install(&hook)
+    Gem.post_uninstall(&hook)
+  rescue
+    warn "rbenv: error installing gem-rehash hooks (#{$!})"
+  end
 end


### PR DESCRIPTION
This is an attempt to work around the fact that Rubygems post_install
hooks may happen multiple times per single `bundle install` and ideally
we want `rbenv rehash` to run only once if new gems have been installed.
However due to Bundler parallelism using `fork` on platforms that
support it, it's impossible for the child processes to communicate with
the master process that it needs to run `rbenv rehash`.

This attempt to hook into Bundler via monkeypatching is brittle and
doesn't get us anywhere because we can't tell whether any gems have been
installed at all, let alone do those gems have executables.