### PR TITLE
Avoid running `rbenv rehash` multiple times during `bundle install`

### DIFF
--- a/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
+++ b/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
@@ -15,13 +15,19 @@ if defined?(Bundler::Installer) && Bundler::Installer.respond_to?(:install)
     class << self
       alias install_without_rbenv_rehash install
       def install(root, definition, options = {})
-        result = install_without_rbenv_rehash(root, definition, options)
         begin
-          if result && Gem.default_path.include?(Bundler.bundle_path.to_s)
-            `rbenv rehash`
+          if Gem.default_path.include?(Bundler.bundle_path.to_s)
+            bin_dir = Gem.bindir(Bundler.bundle_path.to_s)
+            bins_before = File.exist?(bin_dir) ? Dir.entries(bin_dir).size : 2
           end
         rescue
           warn "rbenv: error in Bundler post-install hook (#{$!.class.name}: #{$!.message})"
+        end
+
+        result = install_without_rbenv_rehash(root, definition, options)
+
+        if bin_dir && File.exist?(bin_dir) && Dir.entries(bin_dir).size > bins_before
+          `rbenv rehash`
         end
         result
       end


### PR DESCRIPTION
This is an attempt to work around the fact that Rubygems post_install hooks may happen multiple times per single `bundle install` and ideally we want `rbenv rehash` to run only once after all gems have been installed.