### PR TITLE
Add `rbenv versions --skip-aliases` option

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -81,9 +81,12 @@ remove_outdated_shims() {
 
 # List basenames of executables for every Ruby version
 list_executable_names() {
-  local file
-  for file in "$RBENV_ROOT"/versions/*/bin/*; do
-    echo "${file##*/}"
+  local version file
+  rbenv-versions --bare --skip-aliases | \
+  while read version; do
+    for file in "${RBENV_ROOT}/versions/${version}/bin/"*; do
+      echo "${file##*/}"
+    done
   done
 }
 

--- a/libexec/rbenv-versions
+++ b/libexec/rbenv-versions
@@ -1,13 +1,64 @@
 #!/usr/bin/env bash
 # Summary: List all Ruby versions available to rbenv
-# Usage: rbenv versions [--bare]
+# Usage: rbenv versions [--bare] [--skip-aliases]
 #
 # Lists all Ruby versions found in `$RBENV_ROOT/versions/*'.
 
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-if [ "$1" = "--bare" ]; then
+unset bare
+unset skip_aliases
+for arg; do
+  case "$arg" in
+  --bare ) bare=1 ;;
+  --skip-aliases ) skip_aliases=1 ;;
+  * )
+    rbenv-help --usage versions >&2
+    exit 1
+    ;;
+  esac
+done
+
+versions_dir="${RBENV_ROOT}/versions"
+
+if ! enable -f "${BASH_SOURCE%/*}"/../libexec/rbenv-realpath.dylib realpath 2>/dev/null; then
+  if [ -n "$RBENV_NATIVE_EXT" ]; then
+    echo "rbenv: failed to load \`realpath' builtin" >&2
+    exit 1
+  fi
+
+  READLINK=$(type -p greadlink readlink | head -1)
+  if [ -z "$READLINK" ]; then
+    echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
+    exit 1
+  fi
+
+  resolve_link() {
+    $READLINK "$1"
+  }
+
+  realpath() {
+    local cwd="$PWD"
+    local path="$1"
+    local name
+
+    while [ -n "$path" ]; do
+      name="${path##*/}"
+      [ "$name" = "$path" ] || cd "${path%/*}"
+      path="$(resolve_link "$name" || true)"
+    done
+
+    echo "${PWD}/$name"
+    cd "$cwd"
+  }
+fi
+
+if [ -d "$versions_dir" ]; then
+  versions_dir="$(realpath "$versions_dir")"
+fi
+
+if [ -n "$bare" ]; then
   hit_prefix=""
   miss_prefix=""
   current_version=""
@@ -36,8 +87,12 @@ if [ -n "$include_system" ] && RBENV_VERSION=system rbenv-which ruby >/dev/null 
 fi
 
 shopt -s nullglob
-for path in "${RBENV_ROOT}/versions/"*; do
+for path in "$versions_dir"/*; do
   if [ -d "$path" ]; then
+    if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
+      target="$(realpath "$path")"
+      [ "${target%/*}" != "$versions_dir" ] || continue
+    fi
     print_version "${path##*/}"
   fi
 done

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -139,3 +139,18 @@ OUT
 1.8.7
 OUT
 }
+
+@test "doesn't list symlink aliases when --skip-aliases" {
+  create_version "1.8.7"
+  ln -s "1.8.7" "${RBENV_ROOT}/versions/1.8"
+  mkdir moo
+  ln -s "${PWD}/moo" "${RBENV_ROOT}/versions/1.9"
+
+  run rbenv-versions --bare --skip-aliases
+  assert_success
+
+  assert_output <<OUT
+1.8.7
+1.9
+OUT
+}


### PR DESCRIPTION
Useful in combination with `--bare` to list just the unique version numbers without the extra directory entries that are symlinks to other version numbers in the same directory.

Cherry-picked from #637, which is slated for a post-v1.0 release.