### PR TITLE
Never use hardlinks. Never.

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -113,7 +113,7 @@ install_registered_shims() {
   local shim file
   for shim in $registered_shims; do
     file="${SHIM_PATH}/${shim}"
-    [ -e "$file" ] || ln -f "$PROTOTYPE_SHIM_PATH" "$file"
+    [ -e "$file" ] || cp "$PROTOTYPE_SHIM_PATH" "$file"
   done
 }
 


### PR DESCRIPTION
Make shim copies instead of hardlinks.

Copies consume more diskspace than hardlinks,
but we are talking *kilobytes*. Nobody will notice the difference.

Hardlinks cause serious problems.

They fail:
- On network fileystems (NFS)
- On windows
- On docker (aufs and overlay mounts)

These are common deployment scenarios.
Increasingly so with docker and virtualized runtimes.

rbenv is supposed to make life easier, not harder.
Please remove this misguided optimization.

Fixes #64 #311 #312
