### PR TITLE
add completion block for rbenv-help

### DIFF
--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -15,6 +15,13 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
+# Provide rbenv completions
+if [ "$1" = "--complete" ]; then
+  echo --usage
+  rbenv-commands
+  exit
+fi
+
 command_path() {
   local command="$1"
   command -v rbenv-"$command" || command -v rbenv-sh-"$command" || true


### PR DESCRIPTION
I'm not sure about the proper execution of `rbenv-commands`.

Throughout the codebase I've seen `rbenv commands`, `rbenv-commands`, `command rbenv commands`, and `exec rbenv commands`