### PR TITLE
Add --help and tab completion to rbenv-versions

### DIFF
--- a/libexec/rbenv-completions
+++ b/libexec/rbenv-completions
@@ -10,6 +10,11 @@ if [ -z "$COMMAND" ]; then
   exit 1
 fi
 
+# Provide rbenv completions
+if [ "$COMMAND" = "--complete" ]; then
+  exec rbenv-commands
+fi
+
 COMMAND_PATH="$(command -v "rbenv-$COMMAND" || command -v "rbenv-sh-$COMMAND")"
 
 # --help is provided automatically

--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -18,8 +18,7 @@ set -e
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
   echo --usage
-  rbenv-commands
-  exit
+  exec rbenv-commands
 fi
 
 command_path() {

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -5,6 +5,17 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
+# Provide rbenv completions
+if [ "$1" = "--complete" ]; then
+  echo -
+  echo --no-rehash
+  echo bash
+  echo fish
+  echo ksh
+  echo zsh
+  exit
+fi
+
 print=""
 no_rehash=""
 for args in "$@"

--- a/libexec/rbenv-versions
+++ b/libexec/rbenv-versions
@@ -9,8 +9,13 @@ set -e
 
 unset bare
 unset skip_aliases
+# Provide rbenv completions
 for arg; do
   case "$arg" in
+  --complete )
+    echo --bare
+    echo --skip-aliases
+    exit ;;
   --bare ) bare=1 ;;
   --skip-aliases ) skip_aliases=1 ;;
   * )


### PR DESCRIPTION
- adds --help option for full help
- adds tab completion (--bare, --skip-aliases)

Questions:
- should --help itself be tab completed?
- should --help option be listed in usage?