### PR TITLE
Handle --help flag for subcommands

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -97,7 +97,7 @@ case "$command" in
   } >&2
   exit 1
   ;;
--v )
+-v | --version )
   exec rbenv---version
   ;;
 -h | --help )

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -111,6 +111,10 @@ case "$command" in
   fi
 
   shift 1
-  exec "$command_path" "$@"
+  if [ "$1" = --help ]; then
+    exec rbenv-help "$command"
+  else
+    exec "$command_path" "$@"
+  fi
   ;;
 esac

--- a/libexec/rbenv-completions
+++ b/libexec/rbenv-completions
@@ -11,6 +11,10 @@ if [ -z "$COMMAND" ]; then
 fi
 
 COMMAND_PATH="$(command -v "rbenv-$COMMAND" || command -v "rbenv-sh-$COMMAND")"
+
+# --help is provided automatically
+echo --help
+
 if grep -iE "^([#%]|--|//) provide rbenv completions" "$COMMAND_PATH" >/dev/null; then
   shift
   exec "$COMMAND_PATH" --complete "$@"

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -13,7 +13,7 @@ create_command() {
   create_command "rbenv-hello" "#!$BASH
     echo hello"
   run rbenv-completions hello
-  assert_success ""
+  assert_success "--help"
 }
 
 @test "command with completion support" {
@@ -25,7 +25,11 @@ else
   exit 1
 fi"
   run rbenv-completions hello
-  assert_success "hello"
+  assert_success
+  assert_output <<OUT
+--help
+hello
+OUT
 }
 
 @test "forwards extra arguments" {
@@ -40,6 +44,7 @@ fi"
   run rbenv-completions hello happy world
   assert_success
   assert_output <<OUT
+--help
 happy
 world
 OUT

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -35,6 +35,7 @@ create_executable() {
   run rbenv-completions exec
   assert_success
   assert_output <<OUT
+--help
 rake
 ruby
 OUT


### PR DESCRIPTION
First attempt at handling --help uniformly across all subcommands.

If a subcommand is provided and exists and its first subarg is `-h` or `--help`, intercept the call and exec rbenv-help for the subcommand instead.

Additionally, for tab completion, include `--help` in the completions for a subcommand

Prompted by https://github.com/sstephenson/rbenv/pull/822#discussion_r45077235