### PR TITLE
Fix leftover .ruby-version file from exec.bats

### DIFF
--- a/test/exec.bats
+++ b/test/exec.bats
@@ -21,6 +21,8 @@ create_executable() {
 }
 
 @test "fails with invalid version set from file" {
+  mkdir -p "$RBENV_TEST_DIR"
+  cd "$RBENV_TEST_DIR"
   echo 1.9 > .ruby-version
   run rbenv-exec rspec
   assert_failure "rbenv: version \`1.9' is not installed (set by $PWD/.ruby-version)"


### PR DESCRIPTION
This new test was creating an (intentionally invalid) .ruby-version file
in current working directory; typically the rbenv project dir.
Immediately after test runs, I had a leftover .ruby-version file.

The version-file tests create and cd into the RBENV_TEST_DIR as part of
setup(). I'm using the same directory for this test fix, but am only
using it for this particular test. None of the other exec tests seem to
need to be in a temp test dir, so no use putting it in setup().