### PR TITLE
indentation

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -36,7 +36,7 @@ else
   }
 
   abs_dirname() {
-    local cwd="$(pwd)"
+    local cwd="$PWD"
     local path="$1"
 
     while [ -n "$path" ]; do
@@ -58,10 +58,10 @@ fi
 export RBENV_ROOT
 
 if [ -z "${RBENV_DIR}" ]; then
-  RBENV_DIR="$(pwd)"
+  RBENV_DIR="$PWD"
 else
   cd "$RBENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$RBENV_DIR'"
-  RBENV_DIR="$(pwd)"
+  RBENV_DIR="$PWD"
   cd "$OLDPWD"
 fi
 export RBENV_DIR

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -28,26 +28,26 @@ if enable -f "${BASH_SOURCE%/*}"/../libexec/rbenv-realpath.dylib realpath 2>/dev
 else
   [ -z "$RBENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
 
-READLINK=$(type -p greadlink readlink | head -1)
-[ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
+  READLINK=$(type -p greadlink readlink | head -1)
+  [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
 
-resolve_link() {
-  $READLINK "$1"
-}
+  resolve_link() {
+    $READLINK "$1"
+  }
 
-abs_dirname() {
-  local cwd="$(pwd)"
-  local path="$1"
+  abs_dirname() {
+    local cwd="$(pwd)"
+    local path="$1"
 
-  while [ -n "$path" ]; do
-    cd "${path%/*}"
-    local name="${path##*/}"
-    path="$(resolve_link "$name" || true)"
-  done
+    while [ -n "$path" ]; do
+      cd "${path%/*}"
+      local name="${path##*/}"
+      path="$(resolve_link "$name" || true)"
+    done
 
-  pwd
-  cd "$cwd"
-}
+    pwd
+    cd "$cwd"
+  }
 fi
 
 if [ -z "${RBENV_ROOT}" ]; then


### PR DESCRIPTION
This just fixes the indentation (used vim's out-of-the-box shell formatter)

There is only one non-whitespace change in the PR: switching `$(pwd)` to `$PWD`
This matches a similar change that was made to rbenv-hooks
(7026e529c726648a30af0666088da541245d6422).
rbenv-version-file and rbenv-versions have use `$PWD` since the beginning

https://github.com/sstephenson/rbenv/commit/7026e529c726648a30af0666088da541245d6422#diff-a2b5e4e0b5ebc86ede5c3f80181712a4L38
https://github.com/sstephenson/rbenv/commit/6c1fb9ffd062ff04607d2e0f486067eaf6e48d1e#diff-0b6c3d2c0fa07263937b4ec78b712059R17
https://github.com/sstephenson/rbenv/commit/e80886e9bed1fb51d6df7d37725537fae875e3f6#diff-9befc8fccb1c8d66eaa69fae65f613a5R42

@mislav, this is my last pr, i swear :)